### PR TITLE
Remove session secret fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,9 +3,9 @@
 
 # Required Environment Variables
 JWT_SECRET=your-super-secure-jwt-secret-at-least-32-characters-long
-
-# Optional but Recommended Environment Variables
 SESSION_SECRET=your-session-secret-key-should-be-random-and-secure
+
+# Optional Environment Variables
 WOLFRAM_APP_ID=your-wolfram-alpha-app-id-from-developer-portal
 
 # Development/Production Settings

--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@
 
 # Required Environment Variables
 JWT_SECRET=your-super-secure-jwt-secret-at-least-32-characters-long
-SESSION_SECRET=your-session-secret-key-should-be-random-and-secure
+SESSION_SECRET=your-session-secret-key-at-least-32-characters-long
 
 # Optional Environment Variables
 WOLFRAM_APP_ID=your-wolfram-alpha-app-id-from-developer-portal
@@ -18,6 +18,6 @@ MONGODB_URI=your-mongodb-connection-string-if-using-database
 
 # Security Notes:
 # - JWT_SECRET: Must be at least 32 characters long for security
-# - SESSION_SECRET: Should be a random, secure string
+# - SESSION_SECRET: Should be a random string at least 32 characters long
 # - Never commit actual secrets to version control
 # - Use strong, unique passwords for production deployments

--- a/README.md
+++ b/README.md
@@ -51,11 +51,11 @@ Then edit `.env` with your values:
 ```bash
 OPENAI_API_KEY=your-key-here
 JWT_SECRET=your-super-secure-jwt-secret-at-least-32-characters-long
-SESSION_SECRET=your-session-secret-key
+SESSION_SECRET=your-session-secret-key-at-least-32-characters-long
 PORT=3000
 ```
 
-Both `JWT_SECRET` and `SESSION_SECRET` must be defined before starting the server.
+Both `JWT_SECRET` and `SESSION_SECRET` must be defined before starting the server. Each should be a random string of at least 32 characters.
 
 Run the server:
 

--- a/README.md
+++ b/README.md
@@ -51,8 +51,11 @@ Then edit `.env` with your values:
 ```bash
 OPENAI_API_KEY=your-key-here
 JWT_SECRET=your-super-secure-jwt-secret-at-least-32-characters-long
+SESSION_SECRET=your-session-secret-key
 PORT=3000
 ```
+
+Both `JWT_SECRET` and `SESSION_SECRET` must be defined before starting the server.
 
 Run the server:
 

--- a/server.js
+++ b/server.js
@@ -31,8 +31,8 @@ if (DEBUG) {
 }
 
 // Validate required environment variables
-const requiredEnvVars = ["JWT_SECRET"];
-const recommendedEnvVars = ["SESSION_SECRET", "WOLFRAM_APP_ID"];
+const requiredEnvVars = ["JWT_SECRET", "SESSION_SECRET"];
+const recommendedEnvVars = ["WOLFRAM_APP_ID"];
 
 requiredEnvVars.forEach((varName) => {
   if (!process.env[varName]) {
@@ -115,14 +115,7 @@ app.use(express.urlencoded({ extended: true }));
 // For production scale, consider: connect-mongo, connect-redis, or express-session-file-store
 app.use(
   session({
-    secret:
-      process.env.SESSION_SECRET ||
-      (() => {
-        console.warn(
-          "⚠️  WARNING: Using default session secret. Set SESSION_SECRET environment variable for production!",
-        );
-        return "justice-dashboard-default-secret-" + Date.now();
-      })(),
+    secret: process.env.SESSION_SECRET,
     resave: false,
     saveUninitialized: false,
     cookie: {

--- a/server.js
+++ b/server.js
@@ -55,6 +55,12 @@ if (process.env.JWT_SECRET && process.env.JWT_SECRET.length < 32) {
   );
 }
 
+if (process.env.SESSION_SECRET && process.env.SESSION_SECRET.length < 32) {
+  console.warn(
+    "⚠️  WARNING: SESSION_SECRET should be at least 32 characters long for security.",
+  );
+}
+
 // Initialize Express app
 const app = express();
 app.set("trust proxy", 1); // Trust Render's reverse proxy for rate limiting


### PR DESCRIPTION
## Summary
- require SESSION_SECRET in server setup
- remove default secret generation
- document SESSION_SECRET in README
- adjust `.env.example` to show SESSION_SECRET as required

## Testing
- `npm test`
- `npm run lint` *(fails: parsing error in bundled files)*

------
https://chatgpt.com/codex/tasks/task_e_687af346dc988325968ea322b207f897 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR enhances security by removing the fallback mechanism for session secrets, making SESSION_SECRET a mandatory environment variable with minimum length requirements. Server.js now properly validates environment variables, eliminates default secret generation, and includes a warning check for insufficient secret length. The .env.example file has been updated to clearly indicate these requirements, improving configuration management and developer clarity.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>